### PR TITLE
Atomic alert ID increment

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -80,7 +80,7 @@ impl Database {
             .find_one_and_update(
                 doc! {},
                 doc! {
-                    "$incr": {
+                    "$inc": {
                         "latest_id": 1,
                     },
                     "$setOnInsert": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,6 @@ impl AlertId {
     pub fn from_str(str: &str) -> Result<Self> {
         Ok(AlertId(str.parse()?))
     }
-    pub fn incr(self) -> Self {
-        AlertId(self.0 + 1)
-    }
     pub fn to_le_bytes(self) -> [u8; 8] {
         self.0.to_le_bytes()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,6 @@ impl AlertId {
     pub fn from_str(str: &str) -> Result<Self> {
         Ok(AlertId(str.parse()?))
     }
-    pub fn to_le_bytes(self) -> [u8; 8] {
-        self.0.to_le_bytes()
-    }
     pub fn inner(&self) -> u64 {
         self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,20 +25,8 @@ const MIN_ESCALATION_WINDOW: u64 = 60; // 60 seconds
 pub struct AlertId(u64);
 
 impl AlertId {
-    pub fn from_le_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() != 8 {
-            return Err(anyhow!("failed to fetch current id, invalid length"));
-        }
-
-        let mut id = [0; 8];
-        id.copy_from_slice(&bytes);
-        Ok(AlertId(u64::from_le_bytes(id)))
-    }
-    pub fn from_str(str: &str) -> Result<Self> {
+    fn from_str(str: &str) -> Result<Self> {
         Ok(AlertId(str.parse()?))
-    }
-    pub fn inner(&self) -> u64 {
-        self.0
     }
 }
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -32,7 +32,11 @@ pub struct MatrixClient {
 }
 
 impl MatrixClient {
-    pub async fn new(config: &MatrixConfig, rooms: Vec<String>, handle_user_command: bool) -> Result<Self> {
+    pub async fn new(
+        config: &MatrixConfig,
+        rooms: Vec<String>,
+        handle_user_command: bool,
+    ) -> Result<Self> {
         info!("Setting up Matrix client");
         // Setup client
         let client_config = ClientConfig::new().store_path(&config.db_path);

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -263,14 +263,12 @@ impl Handler<InsertAlerts> for Processor {
             }
 
             // Only store alerts that should escalate.
-            let mut to_store = alerts.clone();
-            to_store.retain(|alert| alert.should_escalate());
-
-            // Store alerts in database.
-            db.insert_alerts(&to_store).await.map_err(|err| {
-                error!("Failed to insert alerts into database: {:?}", err);
-                err
-            })?;
+            if should_escalate {
+                db.insert_alerts(&alerts).await.map_err(|err| {
+                    error!("Failed to insert alerts into database: {:?}", err);
+                    err
+                })?;
+            }
 
             // Notify rooms about all alerts.
             debug!("Notifying rooms about new alerts");


### PR DESCRIPTION
We had an alert ID race condition when multiple alerts are passed on to the webhook too quickly (within milliseconds). The following changes make sure that the ID is incremented in an atomic way on the database level.

This change is backwards compatible and ready to be deployed (tested locally).